### PR TITLE
Logging and jsonl

### DIFF
--- a/scripts/quick_report.py
+++ b/scripts/quick_report.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from statistics import mean
+
+
+def load_latest_file(log_dir: Path) -> list[dict]:
+    files = sorted(log_dir.glob("turns-*.jsonl"))
+    if not files:
+        raise FileNotFoundError("No turn logs found in logs/ directory")
+    latest = files[-1]
+    records = []
+    with latest.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def aggregate(records: list[dict]) -> dict:
+    by_turn: dict[tuple[str, str], dict] = {}
+    for record in records:
+        key = (record.get("session_id"), record.get("turn_id"))
+        by_turn[key] = record
+
+    final_records = list(by_turn.values())
+    total = len(final_records)
+    if total == 0:
+        raise ValueError("No turn records available")
+
+    rewards = [r["reward"] for r in final_records if r.get("reward") is not None]
+    avg_reward = mean(rewards) if rewards else None
+
+    propensity_values = [r["propensity"] for r in final_records if r.get("propensity") is not None]
+    propensity_stats = (
+        {
+            "mean": mean(propensity_values),
+            "min": min(propensity_values),
+            "max": max(propensity_values),
+        }
+        if propensity_values
+        else None
+    )
+
+    style_counter: Counter[str] = Counter()
+    for record in final_records:
+        candidates = record.get("candidates") or []
+        chosen_idx = record.get("chosen_idx")
+        if not isinstance(candidates, list) or chosen_idx is None:
+            continue
+        if 0 <= chosen_idx < len(candidates):
+            style = candidates[chosen_idx].get("style", "unknown")
+            style_counter[style] += 1
+
+    style_win_rates = (
+        {style: count / total for style, count in style_counter.items()}
+        if style_counter
+        else {}
+    )
+
+    unique_choices = len({record.get("chosen_idx") for record in final_records if record.get("chosen_idx") is not None})
+    exploration_rate = unique_choices / total
+
+    return {
+        "turns": total,
+        "avg_reward": avg_reward,
+        "style_win_rates": style_win_rates,
+        "exploration_rate": exploration_rate,
+        "propensity_stats": propensity_stats,
+    }
+
+
+def main() -> None:
+    log_dir = Path(__file__).resolve().parent.parent / "logs"
+    try:
+        records = load_latest_file(log_dir)
+    except FileNotFoundError as exc:
+        print(exc)
+        return
+    try:
+        summary = aggregate(records)
+    except ValueError as exc:
+        print(exc)
+        return
+
+    print("Turn count:", summary["turns"])
+    if summary["avg_reward"] is not None:
+        print(f"Average reward: {summary['avg_reward']:.3f}")
+    else:
+        print("Average reward: n/a (no feedback yet)")
+
+    if summary["style_win_rates"]:
+        print("Style win rates:")
+        for style, rate in sorted(summary["style_win_rates"].items(), key=lambda x: x[1], reverse=True):
+            print(f"  {style}: {rate:.2%}")
+    else:
+        print("Style win rates: n/a")
+
+    print(f"Exploration rate: {summary['exploration_rate']:.2%}")
+
+    stats = summary["propensity_stats"]
+    if stats:
+        print(
+            "Propensity stats: mean={mean:.3f}, min={min:.3f}, max={max:.3f}".format(
+                **stats
+            )
+        )
+    else:
+        print("Propensity stats: n/a")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/app.py
+++ b/src/app.py
@@ -96,6 +96,7 @@ def _build_orchestrator() -> ConversationOrchestrator:
         bandit_manager=bandit_manager,
         feature_extractor=feature_extractor,
         logger=logger,
+        bandit_algo=config.bandit_algo,
     )
     return orchestrator
 

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import json
+import os
+import platform
+import threading
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
 from .types import Candidate, InteractionLogRecord
+
+_APPEND_LOCK = threading.Lock()
 
 
 def _candidate_to_dict(candidate: Candidate) -> Dict[str, Any]:
@@ -16,6 +22,83 @@ def _candidate_to_dict(candidate: Candidate) -> Dict[str, Any]:
         "style": candidate.style,
         "features": candidate.features,
     }
+
+
+def _candidate_preview(candidate: Any) -> Dict[str, Any]:
+    text = ""
+    style = "unknown"
+    features: Dict[str, Any] = {}
+    if isinstance(candidate, Candidate):
+        text = candidate.text
+        style = candidate.style
+        features = candidate.features
+    elif isinstance(candidate, dict):
+        text = str(candidate.get("text", ""))
+        style = str(candidate.get("style", "unknown"))
+        features = candidate.get("features") or {}
+    else:
+        text = str(candidate)
+    return {
+        "style": style,
+        "text_preview": text[:120],
+        "features": features,
+    }
+
+
+def _build_env_versions() -> Dict[str, str]:
+    versions: Dict[str, str] = {"python": platform.python_version()}
+    try:
+        import fastapi
+
+        versions["fastapi"] = fastapi.__version__
+    except Exception:  # pragma: no cover - optional dependency
+        pass
+    try:
+        import uvicorn
+
+        versions["uvicorn"] = uvicorn.__version__
+    except Exception:  # pragma: no cover - optional dependency
+        pass
+    return versions
+
+
+ENV_VERSIONS = _build_env_versions()
+
+
+def log_turn(session_id: str, turn_id: str, payload: Dict[str, Any]) -> None:
+    """Append a single turn entry to a date-partitioned JSONL file."""
+
+    date_str = datetime.utcnow().strftime("%Y%m%d")
+    log_path = Path("logs") / f"turns-{date_str}.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    candidates = payload.get("candidates") or []
+    if isinstance(candidates, Iterable) and not isinstance(candidates, (str, bytes)):
+        candidates_preview = [_candidate_preview(c) for c in candidates]
+    else:
+        candidates_preview = []
+
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "context_hash": payload.get("context_hash"),
+        "candidates": candidates_preview,
+        "chosen_idx": payload.get("chosen_idx"),
+        "propensity": payload.get("propensity"),
+        "reward": payload.get("reward"),
+        "features": payload.get("features"),
+        "bandit_algo": payload.get("bandit_algo")
+        or os.getenv("BANDIT_ALGO")
+        or os.getenv("BANDIT_POLICY"),
+        "env_versions": ENV_VERSIONS,
+    }
+    if "phase" in payload:
+        entry["phase"] = payload["phase"]
+
+    with _APPEND_LOCK:
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
 @dataclass


### PR DESCRIPTION
Built a date-partitioned turn logger and quick analytics script around the new generation pipeline.

src/logging_utils.py:1 now exposes a thread-safe log_turn helper that redacts candidate text previews, records bandit/env metadata, auto-creates logs/turns-YYYYMMDD.jsonl, and still supports the existing JSONL interaction logger.
src/orchestrator.py:1 captures both turn and feedback phases via log_turn, carrying bandit algorithm info, propensity, features, and reward (when available).
src/app.py:1 passes the configured bandit algorithm through to the orchestrator; src/config.py:1 loads .env, surfaces style whitelists, and centralizes runtime settings.
scripts/quick_report.py:1 parses the latest turn log, deduplicates by turn, and prints average reward, style win rates, exploration ratio, and propensity statistics.
Supporting updates propagate candidate features (instead of meta) everywhere, ensure feature imports from src/features, and keep code compiling (python3 -m compileall src scripts).
Tests: python3 -m compileall src scripts (passes). pytest still unavailable in this environment.

Next steps: 1) exercise /turn and /feedback to populate logs/turns-YYYYMMDD.jsonl; 2) run python scripts/quick_report.py to view aggregates; 3) optionally install pytest and run the suite once dependencies are present.