### PR TITLE
Finalizing the api and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,66 @@ MVP that generates N reply candidates, annotates features, exposes action propen
 
 
 ## Run (pseudo)
+```bash
 export OPENAI_API_KEY=...
-python src/app.py
+uvicorn src.app:app --reload
+```
 
+## REST API
+
+### `POST /turn`
+
+Request body
+```json
+{
+  "history": ["以前のやり取り"],
+  "user_utterance": "今どうすればいい？",
+  "N": 3,
+  "session_id": "optional-session"
+}
+```
+
+Response body
+```json
+{
+  "session_id": "optional-session",
+  "turn_id": "generated-turn-id",
+  "reply": "...",
+  "chosen_idx": 1,
+  "propensity": 0.47,
+  "debug": {
+    "scores": [0.12, 0.47, 0.38],
+    "styles": ["empathetic", "logical", "coach"]
+  }
+}
+```
+
+### `POST /feedback`
+
+Request body
+```json
+{
+  "session_id": "optional-session",
+  "turn_id": "generated-turn-id",
+  "chosen_idx": 1,
+  "reward": 0.5
+}
+```
+
+### curl example
+
+```bash
+curl -X POST http://localhost:8000/turn \
+  -H "Content-Type: application/json" \
+  -d '{"history": ["集中できませんでした"], "user_utterance": "今日はどう動く？", "session_id": "demo"}'
+
+curl -X POST http://localhost:8000/feedback \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "demo", "turn_id": "<turn-id-from-turn>", "chosen_idx": 0, "reward": 0.6}'
+```
 
 ## Logs
-Each turn logs: {context_hash, candidates, chosen_idx, propensity, reward, features}.
+
+Each turn appends to `logs/turns-YYYYMMDD.jsonl` with previews, features, bandit metadata and rewards.
+
+Run `python scripts/quick_report.py` to see aggregate reward, style win rates, exploration, and propensity stats.

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -111,6 +111,8 @@ class JsonlInteractionLogger:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
             "context_hash": record.context_hash,
+            "session_id": record.session_id,
+            "turn_id": record.turn_id,
             "candidates": [_candidate_to_dict(c) for c in record.candidates],
             "chosen_idx": record.chosen_idx,
             "propensity": record.propensity,

--- a/src/types.py
+++ b/src/types.py
@@ -49,6 +49,8 @@ class InteractionLogRecord:
     """Structure recorded for every interaction step."""
 
     context_hash: str
+    session_id: str
+    turn_id: str
     candidates: List[Candidate]
     chosen_idx: int
     propensity: float


### PR DESCRIPTION
Refined the API and tightened safety flow end-to-end.

src/app.py:1 now speaks the final schema: POST /turn accepts {history, user_utterance, N?, session_id?}, validates inputs in Japanese, builds the context, and returns {session_id, turn_id, reply, chosen_idx, propensity, debug} while generating fallback IDs. POST /feedback now takes {session_id, turn_id, chosen_idx, reward} with range checks, forwards everything to the orchestrator, and emits localized errors.
src/orchestrator.py:1 tracks interactions by (session_id, turn_id), threads that through logging, and enforces chosen-index consistency. Safety gating now returns both filtered candidates and metadata, and every log line carries session_id/turn_id.
src/types.py:1 and src/logging_utils.py:1 include those identifiers in InteractionLogRecord, while log_turn continues to redact text previews.
src/safety/guard.py:1 exports via src/safety/__init__.py:1, and untouched callers still use reworked guard output.
tests/test_app.py:1 covers the new request/response flow, ensuring session propagation and feedback updates.
README.md:1 documents the finalized API with curl examples, run instructions, and reporting notes.
Validation: python3 -m compileall src scripts (passes). Once dependencies are installed, run pytest and hit the new endpoints (uvicorn src.app:app --reload) to confirm end-to-end behaviour.