### PR TITLE
Test and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi uvicorn numpy pytest httpx ruff
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+select = ["E", "F", "I", "UP"]
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+

--- a/src/safety/guard.py
+++ b/src/safety/guard.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass
-from typing import Iterable, List, Sequence, Tuple
+from typing import List, Sequence, Tuple
 
 from ..types import Candidate
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.generation.generator import CandidateGenerator
+from src.prompt_loader import PromptLoader
+from src.types import GenerationContext, Message
+
+
+def test_candidate_generator_fallback(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    loader = PromptLoader(Path("prompts"))
+    generator = CandidateGenerator(loader)
+
+    context = GenerationContext(
+        messages=[Message(role="user", content="今日は何をすべき？")],
+        candidate_count=2,
+    )
+
+    candidates = generator.generate(context)
+
+    assert len(candidates) == 2
+    for candidate in candidates:
+        assert candidate.text
+        assert candidate.features.get("language") in {"ja", "en"}

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from src.logging_utils import log_turn
+from src.types import Candidate
+
+
+def test_log_turn_creates_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    session_id = "sess"
+    turn_id = "turn"
+    candidates = [
+        Candidate(text="テストメッセージです", style="empathetic", features={}),
+        Candidate(text="二つ目の候補", style="logical", features={}),
+    ]
+
+    payload = {
+        "context_hash": "hash",
+        "candidates": candidates,
+        "chosen_idx": 0,
+        "propensity": 0.5,
+        "reward": None,
+        "features": {},
+        "bandit_algo": "linucb",
+    }
+
+    log_turn(session_id, turn_id, payload)
+
+    date_str = datetime.utcnow().strftime("%Y%m%d")
+    log_path = tmp_path / "logs" / f"turns-{date_str}.jsonl"
+    assert log_path.exists()
+
+    line = log_path.read_text(encoding="utf-8").strip()
+    record = json.loads(line)
+
+    assert record["session_id"] == session_id
+    assert record["turn_id"] == turn_id
+    assert record["candidates"][0]["text_preview"] == "テストメッセージです"
+    assert len(record["candidates"][0]["text_preview"]) <= 120

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from src.safety.guard import review_candidates
+from src.types import Candidate
+
+
+def test_review_candidates_filters_pii():
+    candidates = [
+        Candidate(text="You can call me at 090-1234-5678", style="logical", features={}),
+        Candidate(text="安全なメッセージ", style="empathetic", features={}),
+    ]
+
+    approved, scores, rewrites = review_candidates(candidates, min_score=0.5)
+
+    assert approved == [1]
+    assert scores[0] < 0.5
+    assert rewrites[0]
+    assert not rewrites[1]


### PR DESCRIPTION
Added lint/test scaffolding and coverage around key components.

pyproject.toml now configures Ruff (line length 100, py310 target) and sets pytest’s default tests/ path.
New workflow .github/workflows/ci.yml runs Ruff and pytest on Python 3.10/3.11.
Added targeted tests:
tests/test_generation.py exercises the fallback path of CandidateGenerator.
tests/test_logging_utils.py ensures log_turn creates the dated JSONL with clipped previews.
tests/test_safety.py verifies the safety guard rejects/rewrites PII-laden text.
Updated tests/test_app.py to hit the new /turn//feedback contract.
tests/test_bandit.py and newcomers coexist with the expanded safety API.
Minor clean-ups (unused import removal) to keep Ruff happy.
How to verify locally once deps are installed:

pip install fastapi uvicorn numpy pytest httpx ruff
ruff check .
pytest
If everything succeeds, push and let the new CI matrix double-check.