### PR TITLE
Add minimal UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ Each turn appends to `logs/turns-YYYYMMDD.jsonl` with previews, features, bandit
 
 Run `python scripts/quick_report.py` to see aggregate reward, style win rates, exploration, and propensity stats.
 
+## Web UI
+
+- Start the API (`uvicorn src.app:app --reload`) and open <http://localhost:8000/ui>.
+- 入力フォームにメッセージを送ると候補カードが表示され、クリックでフィードバックが送信されます。
+- 右上の簡易メトリクスは `/metrics` を定期ポーリングして更新されます。
+- **Screenshot placeholder:** _Add UI screenshot here_
+
 ## How to extend
 
 - **Switch bandits**: set `BANDIT_ALGO=lints` (Thompson sampling) or `linucb` (upper-confidence bound) to change exploration behaviour without code changes.

--- a/scripts/quick_report.py
+++ b/scripts/quick_report.py
@@ -1,96 +1,16 @@
 from __future__ import annotations
 
-import json
-from collections import Counter
-from pathlib import Path
-from statistics import mean
-
-
-def load_latest_file(log_dir: Path) -> list[dict]:
-    files = sorted(log_dir.glob("turns-*.jsonl"))
-    if not files:
-        raise FileNotFoundError("No turn logs found in logs/ directory")
-    latest = files[-1]
-    records = []
-    with latest.open("r", encoding="utf-8") as handle:
-        for line in handle:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-    return records
-
-
-def aggregate(records: list[dict]) -> dict:
-    by_turn: dict[tuple[str, str], dict] = {}
-    for record in records:
-        key = (record.get("session_id"), record.get("turn_id"))
-        by_turn[key] = record
-
-    final_records = list(by_turn.values())
-    total = len(final_records)
-    if total == 0:
-        raise ValueError("No turn records available")
-
-    rewards = [r["reward"] for r in final_records if r.get("reward") is not None]
-    avg_reward = mean(rewards) if rewards else None
-
-    propensity_values = [r["propensity"] for r in final_records if r.get("propensity") is not None]
-    propensity_stats = (
-        {
-            "mean": mean(propensity_values),
-            "min": min(propensity_values),
-            "max": max(propensity_values),
-        }
-        if propensity_values
-        else None
-    )
-
-    style_counter: Counter[str] = Counter()
-    for record in final_records:
-        candidates = record.get("candidates") or []
-        chosen_idx = record.get("chosen_idx")
-        if not isinstance(candidates, list) or chosen_idx is None:
-            continue
-        if 0 <= chosen_idx < len(candidates):
-            style = candidates[chosen_idx].get("style", "unknown")
-            style_counter[style] += 1
-
-    style_win_rates = (
-        {style: count / total for style, count in style_counter.items()}
-        if style_counter
-        else {}
-    )
-
-    unique_choices = len({record.get("chosen_idx") for record in final_records if record.get("chosen_idx") is not None})
-    exploration_rate = unique_choices / total
-
-    return {
-        "turns": total,
-        "avg_reward": avg_reward,
-        "style_win_rates": style_win_rates,
-        "exploration_rate": exploration_rate,
-        "propensity_stats": propensity_stats,
-    }
-
 
 def main() -> None:
-    log_dir = Path(__file__).resolve().parent.parent / "logs"
-    try:
-        records = load_latest_file(log_dir)
-    except FileNotFoundError as exc:
-        print(exc)
-        return
-    try:
-        summary = aggregate(records)
-    except ValueError as exc:
-        print(exc)
-        return
+    from pathlib import Path
 
-    print("Turn count:", summary["turns"])
+    from src.metrics import compute_metrics
+
+    log_dir = Path(__file__).resolve().parent.parent / "logs"
+    summary = compute_metrics(log_dir)
+
+    turn_count = summary["turn_count"]
+    print("Turn count:", turn_count)
     if summary["avg_reward"] is not None:
         print(f"Average reward: {summary['avg_reward']:.3f}")
     else:
@@ -105,13 +25,11 @@ def main() -> None:
 
     print(f"Exploration rate: {summary['exploration_rate']:.2%}")
 
-    stats = summary["propensity_stats"]
-    if stats:
-        print(
-            "Propensity stats: mean={mean:.3f}, min={min:.3f}, max={max:.3f}".format(
-                **stats
-            )
-        )
+    mean_value = summary["propensity_mean"]
+    std_value = summary["propensity_std"]
+    if mean_value is not None:
+        std_display = f", std={std_value:.3f}" if std_value is not None else ""
+        print(f"Propensity stats: mean={mean_value:.3f}{std_display}")
     else:
         print("Propensity stats: n/a")
 

--- a/src/app.py
+++ b/src/app.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field, field_validator
 
 from .bandit import BanditManager, LinTS, LinUCB
@@ -14,11 +18,15 @@ from .config import AppConfig, load_config
 from .features import FeatureExtractor
 from .generation import CandidateGenerator
 from .logging_utils import JsonlInteractionLogger
+from .metrics import compute_metrics
 from .orchestrator import ConversationOrchestrator
 from .prompt_loader import PromptLoader
 from .types import GenerationContext, Message
 
 CONFIG: AppConfig = load_config()
+BASE_DIR = Path(__file__).resolve().parent
+UI_DIR = BASE_DIR / "ui"
+templates = Jinja2Templates(directory=str(UI_DIR / "templates"))
 
 
 class TurnRequest(BaseModel):
@@ -104,6 +112,7 @@ def _build_orchestrator() -> ConversationOrchestrator:
 
 
 app = FastAPI(title="Online Conversation Optimizer")
+app.mount("/static", StaticFiles(directory=str(UI_DIR / "static")), name="static")
 _orchestrator = _build_orchestrator()
 _lock = asyncio.Lock()
 
@@ -174,6 +183,133 @@ async def feedback(request: FeedbackRequest) -> dict[str, str]:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return {"status": "ok"}
+
+
+@app.get("/ui", response_class=HTMLResponse)
+async def ui(request: Request) -> HTMLResponse:
+    session_id = str(uuid.uuid4())
+    context = {
+        "request": request,
+        "session_id": session_id,
+        "history_json": "[]",
+        "candidate_count": CONFIG.candidate_count,
+    }
+    return templates.TemplateResponse(request, "index.html", context)
+
+
+@app.get("/metrics")
+async def metrics() -> dict[str, object]:
+    return compute_metrics()
+
+
+@app.post("/api/turn", response_class=HTMLResponse)
+async def api_turn(request: Request) -> HTMLResponse:
+    form = await request.form()
+    user_utterance = (form.get("user_utterance") or "").strip()
+    if not user_utterance:
+        return HTMLResponse("<div class='text-red-400 text-sm'>ユーザ発話を入力してください。</div>", status_code=400)
+
+    history_raw = form.get("history_json") or "[]"
+    try:
+        history_data = json.loads(history_raw)
+        if not isinstance(history_data, list):
+            history_data = []
+    except json.JSONDecodeError:
+        history_data = []
+
+    session_id = (form.get("session_id") or "").strip() or None
+    candidate_count_value = form.get("candidate_count")
+    n_override = None
+    if candidate_count_value:
+        try:
+            n_override = int(candidate_count_value)
+        except ValueError:
+            return HTMLResponse("<div class='text-red-400 text-sm'>候補数は数値で指定してください。</div>", status_code=400)
+
+    payload = {
+        "history": history_data,
+        "user_utterance": user_utterance,
+        "N": n_override,
+        "session_id": session_id,
+    }
+    turn_request = TurnRequest.model_validate(payload)
+
+    candidate_count = turn_request.N or CONFIG.candidate_count
+    if candidate_count <= 0:
+        return HTMLResponse("<div class='text-red-400 text-sm'>Nは正の整数にしてください。</div>", status_code=400)
+    if turn_request.session_id and len(turn_request.session_id) > 128:
+        return HTMLResponse("<div class='text-red-400 text-sm'>session_idが長すぎます。</div>", status_code=400)
+
+    messages = _messages_from_history(turn_request.history, turn_request.user_utterance)
+    context = GenerationContext(
+        messages=messages,
+        candidate_count=candidate_count,
+        styles_allowed=CONFIG.styles_whitelist,
+    )
+    session = turn_request.session_id.strip() if turn_request.session_id else str(uuid.uuid4())
+    turn_id = str(uuid.uuid4())
+
+    async with _lock:
+        result = _orchestrator.run_turn(context, session_id=session, turn_id=turn_id)
+
+    candidates_data = []
+    scores = list(result.decision.scores)
+    propensities = list(result.decision.propensities)
+    for idx, candidate in enumerate(result.candidates):
+        candidates_data.append(
+            {
+                "index": idx,
+                "text": candidate.text,
+                "style": candidate.style,
+                "score": float(scores[idx]),
+                "propensity": float(propensities[idx]),
+                "safety_score": candidate.features.get("safety_score"),
+                "session_id": result.session_id,
+                "turn_id": result.turn_id,
+            }
+        )
+
+    context = {
+        "request": request,
+        "session_id": result.session_id,
+        "turn_id": result.turn_id,
+        "scores": scores,
+        "propensities": propensities,
+        "candidates": candidates_data,
+    }
+    return templates.TemplateResponse(request, "partials/candidates.html", context)
+
+
+@app.post("/api/feedback")
+async def api_feedback(request: Request) -> dict[str, object]:
+    payload = await request.json()
+    data = {
+        "session_id": payload.get("session_id"),
+        "turn_id": payload.get("turn_id"),
+        "chosen_idx": payload.get("chosen_idx"),
+        "reward": payload.get("reward", 1.0),
+    }
+    feedback_request = FeedbackRequest.model_validate(data)
+    latency_ms = payload.get("latency_ms")
+    continued = payload.get("continued")
+
+    if feedback_request.reward < -1.0 or feedback_request.reward > 1.0:
+        raise HTTPException(status_code=400, detail="rewardは-1.0から1.0の範囲で指定してください")
+
+    async with _lock:
+        try:
+            _orchestrator.apply_feedback(
+                feedback_request.session_id,
+                feedback_request.turn_id,
+                feedback_request.chosen_idx,
+                feedback_request.reward,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {"status": "ok", "latency_ms": latency_ms, "continued": continued}
 
 
 __all__ = ["app"]

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,98 @@
+"""Utilities for computing turn metrics from logs."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from statistics import mean, pstdev
+from typing import Any
+
+DEFAULT_LOG_DIR = Path("logs")
+
+
+def _load_latest_records(log_dir: Path) -> list[dict[str, Any]]:
+    files = sorted(log_dir.glob("turns-*.jsonl"))
+    if not files:
+        return []
+    latest = files[-1]
+    records: list[dict[str, Any]] = []
+    with latest.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            content = line.strip()
+            if not content:
+                continue
+            try:
+                records.append(json.loads(content))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def compute_metrics(log_dir: Path | None = None) -> dict[str, Any]:
+    """Return aggregate metrics using the latest JSONL log.
+
+    The returned dictionary contains keys: turn_count, avg_reward,
+    style_win_rates, exploration_rate, propensity_mean, propensity_std.
+    """
+
+    directory = log_dir or DEFAULT_LOG_DIR
+    records = _load_latest_records(directory)
+    by_turn: dict[tuple[str | None, str | None], dict[str, Any]] = {}
+    for record in records:
+        key = (record.get("session_id"), record.get("turn_id"))
+        by_turn[key] = record
+
+    final_records = list(by_turn.values())
+    total = len(final_records)
+    if total == 0:
+        return {
+            "turn_count": 0,
+            "avg_reward": None,
+            "style_win_rates": {},
+            "exploration_rate": 0.0,
+            "propensity_mean": None,
+            "propensity_std": None,
+        }
+
+    rewards = [r["reward"] for r in final_records if r.get("reward") is not None]
+    avg_reward = mean(rewards) if rewards else None
+
+    prop_values = [r["propensity"] for r in final_records if r.get("propensity") is not None]
+    prop_mean = mean(prop_values) if prop_values else None
+    prop_std = pstdev(prop_values) if len(prop_values) > 1 else 0.0 if prop_values else None
+
+    style_counter: Counter[str] = Counter()
+    for record in final_records:
+        candidates = record.get("candidates") or []
+        chosen_idx = record.get("chosen_idx")
+        if not isinstance(candidates, list) or chosen_idx is None:
+            continue
+        if 0 <= chosen_idx < len(candidates):
+            style = candidates[chosen_idx].get("style", "unknown")
+            style_counter[style] += 1
+
+    style_win_rates = (
+        {style: count / total for style, count in style_counter.items()}
+        if style_counter
+        else {}
+    )
+
+    unique_indices = {
+        record.get("chosen_idx")
+        for record in final_records
+        if record.get("chosen_idx") is not None
+    }
+    exploration_rate = (len(unique_indices) / total) if total else 0.0
+
+    return {
+        "turn_count": total,
+        "avg_reward": avg_reward,
+        "style_win_rates": style_win_rates,
+        "exploration_rate": exploration_rate,
+        "propensity_mean": prop_mean,
+        "propensity_std": prop_std,
+    }
+
+
+__all__ = ["compute_metrics"]

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -1,0 +1,26 @@
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.message.user {
+  border-color: rgba(99, 102, 241, 0.6);
+  background-color: rgba(99, 102, 241, 0.15);
+}
+
+.message.assistant {
+  border-color: rgba(79, 70, 229, 0.4);
+}
+
+#candidates .candidate-card {
+  transition: transform 0.15s ease;
+}
+
+#candidates .candidate-card:hover {
+  transform: translateY(-2px);
+}
+
+@media (max-width: 1024px) {
+  aside {
+    display: none;
+  }
+}

--- a/src/ui/static/app.js
+++ b/src/ui/static/app.js
@@ -1,0 +1,197 @@
+
+(function () {
+  const state = {
+    history: [],
+    sessionId: null,
+    pendingUser: null,
+    lastTurnResponseAt: null,
+  };
+
+  const conversation = document.getElementById('conversation');
+  const candidatesBox = document.getElementById('candidates');
+  const historyInput = document.getElementById('history-json');
+  const sessionInput = document.getElementById('session-id');
+  const messageInput = document.getElementById('user-utterance');
+  const form = document.getElementById('turn-form');
+  const statusMessage = document.getElementById('status-message');
+
+  function ensureSessionId() {
+    if (sessionInput.value) {
+      state.sessionId = sessionInput.value;
+      return;
+    }
+    const fallback = 'sess-' + Date.now();
+    const id = (self.crypto && self.crypto.randomUUID) ? self.crypto.randomUUID() : fallback;
+    state.sessionId = id;
+    sessionInput.value = id;
+  }
+
+  function updateHistoryInput() {
+    historyInput.value = JSON.stringify(state.history);
+  }
+
+  function appendMessage(role, text) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'message ' + role + ' rounded-md border border-slate-800 bg-slate-900/60 px-4 py-3';
+    const label = document.createElement('div');
+    label.className = 'text-xs text-slate-400 mb-1';
+    label.textContent = role === 'user' ? 'ユーザ' : 'アシスタント';
+    const body = document.createElement('p');
+    body.className = 'whitespace-pre-line text-slate-100';
+    body.textContent = text;
+    wrapper.appendChild(label);
+    wrapper.appendChild(body);
+    conversation.appendChild(wrapper);
+    conversation.scrollTop = conversation.scrollHeight;
+    return wrapper;
+  }
+
+  function removeLastUserMessage() {
+    const last = conversation.lastElementChild;
+    if (!last) {
+      return;
+    }
+    if (last.className && last.className.indexOf('message user') !== -1) {
+      conversation.removeChild(last);
+    }
+  }
+
+  function handleCandidateClick(event) {
+    const card = event.target.closest('.candidate-card');
+    if (!card || card.dataset.disabled === 'true') {
+      return;
+    }
+    const candidate = JSON.parse(card.dataset.candidate);
+    const latencyMs = state.lastTurnResponseAt ? Math.round(performance.now() - state.lastTurnResponseAt) : null;
+    const payload = {
+      session_id: candidate.session_id,
+      turn_id: candidate.turn_id,
+      chosen_idx: candidate.index,
+      reward: 1.0,
+      latency_ms: latencyMs,
+      continued: true,
+    };
+    card.dataset.disabled = 'true';
+    fetch('/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('feedback failed');
+        }
+        return response.json();
+      })
+      .then(function () {
+        appendMessage('assistant', candidate.text);
+        if (state.pendingUser !== null) {
+          state.history.push(state.pendingUser);
+        }
+        state.history.push(candidate.text);
+        state.pendingUser = null;
+        messageInput.value = '';
+        candidatesBox.innerHTML = '';
+        updateHistoryInput();
+        statusMessage.textContent = '';
+        refreshMetrics();
+      })
+      .catch(function () {
+        statusMessage.textContent = 'フィードバックに失敗しました';
+      })
+      .finally(function () {
+        delete card.dataset.disabled;
+      });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    ensureSessionId();
+    updateHistoryInput();
+    refreshMetrics();
+    setInterval(refreshMetrics, 5000);
+    candidatesBox.addEventListener('click', handleCandidateClick);
+  });
+
+  form.addEventListener('submit', function (event) {
+    const message = messageInput.value.trim();
+    if (!message) {
+      event.preventDefault();
+      statusMessage.textContent = '入力してください';
+      return;
+    }
+    state.pendingUser = message;
+    updateHistoryInput();
+    appendMessage('user', message);
+    candidatesBox.innerHTML = '';
+    statusMessage.textContent = '候補を生成中...';
+  });
+
+  document.body.addEventListener('htmx:afterSwap', function (event) {
+    if (event.target === candidatesBox) {
+      statusMessage.textContent = '';
+      state.lastTurnResponseAt = performance.now();
+      const list = candidatesBox.querySelector('#candidate-list');
+      if (!list) {
+        return;
+      }
+      const sessionId = list.dataset.sessionId;
+      const turnId = list.dataset.turnId;
+      list.querySelectorAll('.candidate-card').forEach(function (card) {
+        const candidate = JSON.parse(card.dataset.candidate);
+        candidate.session_id = sessionId;
+        candidate.turn_id = turnId;
+        card.dataset.candidate = JSON.stringify(candidate);
+      });
+    }
+  });
+
+  document.body.addEventListener('htmx:responseError', function (event) {
+    if (event.target === form) {
+      statusMessage.textContent = '候補生成に失敗しました';
+      removeLastUserMessage();
+      state.pendingUser = null;
+    }
+  });
+
+  function renderMetrics(data) {
+    document.getElementById('metric-turn-count').textContent = data.turn_count != null ? data.turn_count : '-';
+    const avg = data.avg_reward;
+    document.getElementById('metric-avg-reward').textContent =
+      avg !== null && avg !== undefined ? avg.toFixed(3) : 'n/a';
+    const exploration = data.exploration_rate != null ? data.exploration_rate : 0;
+    document.getElementById('metric-exploration').textContent = Math.round(exploration * 100) + '%';
+    const meanValue = data.propensity_mean;
+    const stdValue = data.propensity_std;
+    if (meanValue !== null && meanValue !== undefined) {
+      const stdPart = (stdValue !== null && stdValue !== undefined) ? ' / σ=' + stdValue.toFixed(3) : '';
+      document.getElementById('metric-propensity').textContent = meanValue.toFixed(3) + stdPart;
+    } else {
+      document.getElementById('metric-propensity').textContent = 'n/a';
+    }
+    const list = document.getElementById('metric-style-rates');
+    list.innerHTML = '';
+    if (data.style_win_rates) {
+      Object.entries(data.style_win_rates)
+        .sort(function (a, b) { return b[1] - a[1]; })
+        .forEach(function (entry) {
+          const style = entry[0];
+          const rate = entry[1];
+          const item = document.createElement('li');
+          item.textContent = style + ': ' + (rate * 100).toFixed(1) + '%';
+          list.appendChild(item);
+        });
+    }
+  }
+
+  function refreshMetrics() {
+    fetch('/metrics')
+      .then(function (response) { return response.ok ? response.json() : null; })
+      .then(function (data) {
+        if (!data) {
+          return;
+        }
+        renderMetrics(data);
+      })
+      .catch(function () {});
+  }
+})();

--- a/src/ui/templates/index.html
+++ b/src/ui/templates/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Online Conversation Optimizer</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+    <link rel="stylesheet" href="/static/app.css" />
+    <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
+    <script src="/static/app.js" defer></script>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div class="min-h-screen flex">
+      <main class="flex-1 max-w-4xl mx-auto w-full py-6 px-4 lg:px-8">
+        <header class="mb-6">
+          <h1 class="text-2xl font-semibold">Online Conversation Optimizer</h1>
+          <p class="text-sm text-slate-400 mt-1">
+            フォームに入力して候補を生成し、最終返信を選択してください。
+          </p>
+        </header>
+        <section id="conversation" class="space-y-3 mb-6 overflow-y-auto max-h-[45vh] pr-2">
+        </section>
+        <section class="mb-6">
+          <div id="candidates" class="grid gap-3"></div>
+        </section>
+        <form id="turn-form" class="flex flex-col gap-3" hx-post="/api/turn" hx-target="#candidates" hx-swap="innerHTML">
+          <input type="hidden" name="history_json" id="history-json" value="{{ history_json }}" />
+          <input type="hidden" name="session_id" id="session-id" value="{{ session_id }}" />
+          <input type="hidden" name="candidate_count" id="candidate-count" value="{{ candidate_count }}" />
+          <label class="block">
+            <span class="text-sm text-slate-300">ユーザ発話</span>
+            <textarea
+              id="user-utterance"
+              name="user_utterance"
+              rows="3"
+              class="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              placeholder="今日はどう動く？"
+              required
+            ></textarea>
+          </label>
+          <div class="flex items-center gap-3">
+            <button
+              type="submit"
+              class="rounded-md bg-indigo-500 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            >
+              候補を生成
+            </button>
+            <div id="status-message" class="text-sm text-slate-400"></div>
+          </div>
+        </form>
+      </main>
+      <aside class="w-72 bg-slate-900/60 border-l border-slate-800 p-4 hidden lg:flex flex-col gap-4">
+        <div>
+          <h2 class="text-sm font-semibold text-slate-300">メトリクス</h2>
+          <dl id="metrics-box" class="mt-2 space-y-2 text-sm text-slate-300">
+            <div>
+              <dt class="text-slate-400">ターン数</dt>
+              <dd id="metric-turn-count">-</dd>
+            </div>
+            <div>
+              <dt class="text-slate-400">平均報酬</dt>
+              <dd id="metric-avg-reward">-</dd>
+            </div>
+            <div>
+              <dt class="text-slate-400">探索率</dt>
+              <dd id="metric-exploration">-</dd>
+            </div>
+            <div>
+              <dt class="text-slate-400">プロペンシティ</dt>
+              <dd id="metric-propensity">-</dd>
+            </div>
+          </dl>
+        </div>
+        <div>
+          <h2 class="text-sm font-semibold text-slate-300">スタイル勝率</h2>
+          <ul id="metric-style-rates" class="mt-2 text-sm text-slate-300 space-y-1"></ul>
+        </div>
+      </aside>
+    </div>
+  </body>
+</html>

--- a/src/ui/templates/partials/candidates.html
+++ b/src/ui/templates/partials/candidates.html
@@ -1,0 +1,28 @@
+<div
+  class="grid gap-3"
+  id="candidate-list"
+  data-session-id="{{ session_id }}"
+  data-turn-id="{{ turn_id }}"
+  data-propensities='{{ propensities | tojson }}'
+  data-scores='{{ scores | tojson }}'
+>
+  {% for candidate in candidates %}
+  <div
+    class="candidate-card rounded-md border border-slate-700 bg-slate-900 p-4 hover:border-indigo-500 cursor-pointer transition"
+    data-index="{{ candidate.index }}"
+    data-candidate='{{ candidate | tojson }}'
+  >
+    <div class="flex items-center justify-between text-sm text-slate-300">
+      <span class="font-medium text-indigo-300">{{ candidate.style }}</span>
+      <span>Score: {{ '{:.3f}'.format(candidate.score) }}</span>
+    </div>
+    <p class="mt-2 text-slate-100 whitespace-pre-line">{{ candidate.text }}</p>
+    <div class="mt-3 flex flex-wrap gap-3 text-xs text-slate-400">
+      <span>Propensity: {{ '{:.3f}'.format(candidate.propensity) }}</span>
+      {% if candidate.safety_score is not none %}
+      <span>Safety: {{ '{:.2f}'.format(candidate.safety_score) }}</span>
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+</div>

--- a/src/ui/templates/partials/message.html
+++ b/src/ui/templates/partials/message.html
@@ -1,0 +1,4 @@
+<div class="message {{ role }} rounded-md border border-slate-800 bg-slate-900/60 px-4 py-3">
+  <div class="text-xs text-slate-400 mb-1">{{ label }}</div>
+  <p class="whitespace-pre-line text-slate-100">{{ text }}</p>
+</div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -48,3 +50,52 @@ def test_turn_and_feedback(tmp_path, monkeypatch):
     with log_path.open("r", encoding="utf-8") as handle:
         lines = handle.readlines()
     assert len(lines) == 2  # turn + feedback entries
+
+    metrics_response = client.get("/metrics")
+    assert metrics_response.status_code == 200
+    metrics = metrics_response.json()
+    assert metrics["turn_count"] >= 1
+
+
+def test_api_turn_and_feedback(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_PATH", str(tmp_path / "interactions.jsonl"))
+    monkeypatch.setenv("CANDIDATE_COUNT", "2")
+
+    if "src.app" in sys.modules:
+        importlib.invalidate_caches()
+        sys.modules.pop("src.app")
+
+    app_module = importlib.import_module("src.app")
+    client = TestClient(app_module.app)
+
+    form_data = {
+        "history_json": "[]",
+        "user_utterance": "今日はどう動く？",
+        "session_id": "ui-session",
+        "candidate_count": "2",
+    }
+    response = client.post("/api/turn", data=form_data)
+    assert response.status_code == 200
+    html = response.text
+    assert "candidate-card" in html
+
+    session_match = re.search(r'data-session-id="([^"]+)"', html)
+    turn_match = re.search(r'data-turn-id="([^"]+)"', html)
+    candidate_match = re.search(r"data-candidate='([^']+)'", html)
+    assert session_match and turn_match and candidate_match
+
+    session_id = session_match.group(1)
+    turn_id = turn_match.group(1)
+    candidate_payload = json.loads(candidate_match.group(1))
+
+    feedback_payload = {
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "chosen_idx": candidate_payload["index"],
+        "reward": 1.0,
+        "latency_ms": 42,
+        "continued": True,
+    }
+    feedback_response = client.post("/api/feedback", json=feedback_payload)
+    assert feedback_response.status_code == 200
+    assert feedback_response.json()["status"] == "ok"

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.logging_utils import log_turn
 from src.types import Candidate
@@ -29,7 +29,7 @@ def test_log_turn_creates_file(tmp_path, monkeypatch):
 
     log_turn(session_id, turn_id, payload)
 
-    date_str = datetime.utcnow().strftime("%Y%m%d")
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
     log_path = tmp_path / "logs" / f"turns-{date_str}.jsonl"
     assert log_path.exists()
 


### PR DESCRIPTION
Added a minimal browser UI (/ui) powered by HTMX + vanilla JS, rendering candidate cards, capturing feedback clicks (with latency reporting), and polling a live metrics box.
Broke out turn-log aggregation into compute_metrics and reused it in both the new /metrics API and the CLI quick-report script; refreshed logging timestamps to be timezone-aware.
Relaxed bandit feedback to accept any chosen candidate index, plus tightened request validation and updated README with UI instructions & placeholder screenshot.